### PR TITLE
Use usethis::use_package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,8 @@ Imports:
     stringi,
     stringr,
     tibble,
-    tidyr
+    tidyr,
+    usethis
 Suggests: 
     testthat
 LazyData: TRUE

--- a/R/utils.R
+++ b/R/utils.R
@@ -113,7 +113,9 @@ lsos <- function(pos = 1, pattern, order.by = "Size",
 #' @export
 use_pipe <- function(pkg = ".") {
   pkg <- devtools::as.package(pkg)
-  devtools::use_package("magrittr", pkg = pkg)
+  usethis::with_project(pkg$path,
+    usethis::use_package("magrittr", pkg = pkg)
+  )
   txt_pipe <- readLines(system.file("pipe-op.R",
     package = "abjutils"
   ))

--- a/R/utils.R
+++ b/R/utils.R
@@ -112,6 +112,7 @@ lsos <- function(pos = 1, pattern, order.by = "Size",
 #'
 #' @export
 use_pipe <- function(pkg = ".") {
+  .Deprecated("usethis::use_pipe")
   pkg <- devtools::as.package(pkg)
   usethis::with_project(pkg$path,
     usethis::use_package("magrittr", pkg = pkg)


### PR DESCRIPTION
use_package has been deprecated in devtools 2.0.0 and removed in
devtools 2.1.0

Also there is already a [`use_pipe()`](https://usethis.r-lib.org/reference/use_pipe.html) function in usethis, perhaps you would want to remove this implementation and just use that?