### PR TITLE
Arrumando o warning do separate_cnj()

### DIFF
--- a/R/cnj.R
+++ b/R/cnj.R
@@ -217,9 +217,8 @@ build_id <- function(id) {
 #'
 #' @export
 separate_cnj <- function(data, col, ...) {
-  col <- rlang::enquo(col)
   tidyr::separate(
-    data, rlang::UQ(col),
+    data, {{col}},
     into = c("N", "D", "A", "J", "T", "O"), sep = "[\\-\\.]", ...
   )
 }

--- a/tests/testthat/test-separate_cnj.R
+++ b/tests/testthat/test-separate_cnj.R
@@ -1,0 +1,15 @@
+
+context("Funcoes de separate")
+
+test_that("separate_cnj funciona sem warning", {
+  library(magrittr)
+  da <- tibble::tibble(
+    a = "1000315-72.2016.8.26.0156"
+  )
+  
+  
+  testthat::expect_warning(resp <- separate_cnj(da, a), regexp = NA)
+  
+  testthat::expect_equal(class(resp), c("tbl_df", "tbl", "data.frame"))
+  testthat::expect_equal(dim(resp), c(1,6))
+})


### PR DESCRIPTION
Relacionada com a issue #16

Eu vi que o pacote rlang mudou e o UQ ficou obsoleto. Troquei pelo {{}}.